### PR TITLE
dynamic-matrix updates

### DIFF
--- a/.github/workflows/dynamic-matrix.yml
+++ b/.github/workflows/dynamic-matrix.yml
@@ -48,6 +48,7 @@ jobs:
           echo "json-output=${json}" >> $GITHUB_OUTPUT
 
   run-with-json:
+    name: run-with-json-${{ matrix.iteration.directory }}-${{ matrix.iteration.artifact }}
     runs-on: ubuntu-latest
     needs: outputs-static
     strategy:

--- a/.github/workflows/dynamic-matrix.yml
+++ b/.github/workflows/dynamic-matrix.yml
@@ -151,6 +151,7 @@ jobs:
         run: echo ${{ matrix.iteration.name }}
 
   matrix-object-reusable:
+    name: matrix-object-reusable-${{ matrix.iteration.name }}-${{ matrix.iteration.value }}
     needs: output-object
     strategy:
       matrix:

--- a/.github/workflows/dynamic-matrix.yml
+++ b/.github/workflows/dynamic-matrix.yml
@@ -23,6 +23,12 @@ permissions:
   contents: read
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "inputs_run: ${{ env.inputs_run }}"
+
   outputs-static:
     if: |
       github.env.inputs_run == 'outputs-static' ||

--- a/.github/workflows/dynamic-matrix.yml
+++ b/.github/workflows/dynamic-matrix.yml
@@ -16,23 +16,25 @@ on:
     paths:
       - .github/workflows/dynamic-matrix.yml
 
-env:
-  inputs_run: ${{ inputs.run || 'all' }}
-
 permissions:
   contents: read
 
 jobs:
-  debug:
+  process-run:
     runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.set-run.outputs.run }}
     steps:
-      - run: |
-          echo "inputs_run: ${{ env.inputs_run }}"
+      - name: Set Run
+        id: set-run
+        run: |
+          echo "run=${{ inputs.run || 'all' }}" >> $GITHUB_OUTPUT
 
   outputs-static:
+    needs: process-run
     if: |
-      github.env.inputs_run == 'outputs-static' ||
-      github.env.inputs_run == 'all'
+      needs.process-run.outputs.run == 'outputs-static' ||
+      needs.process-run.outputs.run == 'all'
     runs-on: ubuntu-latest
     outputs:
       json-output: ${{ steps.set-output.outputs.json-output }}
@@ -70,9 +72,10 @@ jobs:
           echo hello
 
   outputs-array:
+    needs: process-run
     if: |
-      github.env.inputs_run == 'outputs-array' ||
-      github.env.inputs_run == 'all'
+      needs.process-run.outputs.run == 'outputs-array' ||
+      needs.process-run.outputs.run == 'all'
     runs-on: ubuntu-latest
     outputs:
       random-number: ${{ steps.random-number.outputs.result }}
@@ -107,9 +110,10 @@ jobs:
         run: echo ${{ matrix.iteration }} >> $GITHUB_STEP_SUMMARY
 
   output-object:
+    needs: process-run
     if: |
-      github.env.inputs_run == 'output-object' ||
-      github.env.inputs_run == 'all'
+      needs.process-run.outputs.run == 'output-object' ||
+      needs.process-run.outputs.run == 'all'
     runs-on: ubuntu-latest
     outputs:
       random-object: ${{ steps.random-object.outputs.result }}

--- a/.github/workflows/dynamic-matrix.yml
+++ b/.github/workflows/dynamic-matrix.yml
@@ -10,6 +10,14 @@ on:
           - matrix-array
           - matrix-object
           - all
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/dynamic-matrix.yml
+
+env:
+  inputs_run: ${{ github.event.inputs.run || 'all' }}
 
 permissions:
   contents: read
@@ -17,8 +25,8 @@ permissions:
 jobs:
   outputs-static:
     if: |
-      inputs.run == 'outputs-static' ||
-      inputs.run == 'all'
+      github.env.inputs_run == 'outputs-static' ||
+      github.env.inputs_run == 'all'
     runs-on: ubuntu-latest
     outputs:
       json-output: ${{ steps.set-output.outputs.json-output }}
@@ -57,8 +65,8 @@ jobs:
 
   outputs-array:
     if: |
-      inputs.run == 'outputs-array' ||
-      inputs.run == 'all'
+      github.env.inputs_run == 'outputs-array' ||
+      github.env.inputs_run == 'all'
     runs-on: ubuntu-latest
     outputs:
       random-number: ${{ steps.random-number.outputs.result }}
@@ -94,8 +102,8 @@ jobs:
 
   output-object:
     if: |
-      inputs.run == 'output-object' ||
-      inputs.run == 'all'
+      github.env.inputs_run == 'output-object' ||
+      github.env.inputs_run == 'all'
     runs-on: ubuntu-latest
     outputs:
       random-object: ${{ steps.random-object.outputs.result }}

--- a/.github/workflows/dynamic-matrix.yml
+++ b/.github/workflows/dynamic-matrix.yml
@@ -17,7 +17,7 @@ on:
       - .github/workflows/dynamic-matrix.yml
 
 env:
-  inputs_run: ${{ github.event.inputs.run || 'all' }}
+  inputs_run: ${{ inputs.run || 'all' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Changes to trigger and job dependencies:

* Added a `pull_request` trigger for the `main` branch and specified paths to the workflow file.
* Updated the `outputs-static`, `outputs-array`, and `output-object` jobs to depend on the new `process-run` job and modified their conditions to use the output of `process-run`. [[1]](diffhunk://#diff-841f21660c1065d01d31c062d6b6cbe1f3afbb010ef11f54823f59c976376740R51) [[2]](diffhunk://#diff-841f21660c1065d01d31c062d6b6cbe1f3afbb010ef11f54823f59c976376740R76-R79) [[3]](diffhunk://#diff-841f21660c1065d01d31c062d6b6cbe1f3afbb010ef11f54823f59c976376740R114-R117)

Changes to job names:

* Added dynamic naming to the `run-with-json` and `matrix-object-reusable` jobs to include matrix iteration details in the job names. [[1]](diffhunk://#diff-841f21660c1065d01d31c062d6b6cbe1f3afbb010ef11f54823f59c976376740R51) [[2]](diffhunk://#diff-841f21660c1065d01d31c062d6b6cbe1f3afbb010ef11f54823f59c976376740R154)